### PR TITLE
chat: %u endpoints for message existence check

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -723,6 +723,26 @@
     =-  ``chat-draft+!>(-)
     `draft:c`[whom (~(gut by drafts) whom *story:c)]
   ::
+      [%u %dm @ *]
+    =/  =ship  (slav %p i.t.t.path)
+    ?.  (~(has by dms) ship)
+      ``flag+!>(|)
+    (di-peek:(di-abed:di-core ship) t.t.t.path)
+  ::
+      [%u %club @ *]
+    =/  =id:club:c  (slav %uv i.t.t.path)
+    ?.  (~(has by clubs) id)
+      ``flag+!>(|)
+    (cu-peek:(cu-abed:cu-core id) t.t.t.path)
+  ::
+      [%u %chat @ @ *]
+    =/  =flag:c
+        :-  (slav %p i.t.t.path)
+        (slav %tas i.t.t.t.path)
+    ?.  (~(has by chats) flag)
+      ``flag+!>(|)
+    (ca-peek:(ca-abed:ca-core flag) t.t.t.t.path)
+  ::
   ==
 ::
 ++  chats-light

--- a/desk/lib/dm.hoon
+++ b/desk/lib/dm.hoon
@@ -94,6 +94,11 @@
   =*  on   on:writs:c
   ?+    pole  [~ ~]
   ::
+      [%exists author=@ time=@ ~]
+    =/  author  (slav %p author.pole)
+    =/  time  (slav %ud time.pole)
+    ``flag+!>(?~((get author `@da`time) | &))
+  ::
       [%newest count=@ ~]
     =/  count  (slav %ud count.pole)
     ``chat-writs+!>((gas:on *writs:c (top:mope wit.pac count)))


### PR DESCRIPTION
This came about while writing message scries in `%talk-cli`. We needed a `%u` endpoint to avoid crashing the agent in the case where a message retreival fails.

I followed the `writ` path logic so this endpoint also ends in `dm.hoon`. The scry paths are: `/u/chat/<ship>/<name>/writs/exists/<author-ship>/<id>` `/u/dm/<ship>/writs/exists/<author-ship>/<id>`
`/u/club/<club-id>/writs/exists/<author-ship>/<id>`

Should have done this on master branch; better to include in overall PR. 